### PR TITLE
Add additional #to_s before calling underscore

### DIFF
--- a/lib/rails_erd_d3.rb
+++ b/lib/rails_erd_d3.rb
@@ -46,7 +46,7 @@ class RailsErdD3
       model.reflections.each do |refl_name, refl_data|
         next if refl_data.options[:polymorphic]
 
-        refl_model = (refl_data.options[:class_name] || refl_name).underscore
+        refl_model = (refl_data.options[:class_name] || refl_name).to_s.underscore
         association = refl_data.macro.to_s + (refl_data.options[:through] ? "_through" : "")
         color_index = ASSOCIATIONS.index(association)
 


### PR DESCRIPTION
For example, `has_many :users, class_name: User` will return `undefined method underscore' for #<Class:0x007ffd39133df8>`. Therefore, we need to add additional check for string.