### PR TITLE
Looking for ancestors rather than superclass

### DIFF
--- a/lib/rails_erd_d3.rb
+++ b/lib/rails_erd_d3.rb
@@ -26,7 +26,7 @@ class RailsErdD3
 
     Rails.application.eager_load!
     klass.connection
-    @@models = ObjectSpace.each_object(Class).select { |o| o.superclass == klass } || []
+    @@models = ObjectSpace.each_object(Class).select { |o| o.ancestors.include? klass } || []
   end
 
   def self.get_data


### PR DESCRIPTION
Consider STI. 

Suppose we have `UserAccount` and `AdminAccount` where both inherits from `Account`. In this case we want to use both User and Admin accounts as a separate models. Moreover, `target` option of `links` will return `nil` if we will associate inherited types from User or Admin accounts. 