### PR TITLE
Specify more correct target name

### DIFF
--- a/lib/rails_erd_d3.rb
+++ b/lib/rails_erd_d3.rb
@@ -50,9 +50,14 @@ class RailsErdD3
         association = refl_data.macro.to_s + (refl_data.options[:through] ? "_through" : "")
         color_index = ASSOCIATIONS.index(association)
 
+
+        targeted_model = refl_model
+        targeted_model = targeted_model[1..-1] if targeted_model.starts_with?('/')
+        targeted_model = targeted_model.tr('/', '_').pluralize.capitalize
+
         links << {
           source: models_list[model.model_name.plural.capitalize],
-          target: models_list[refl_model.pluralize.capitalize],
+          target: models_list[targeted_model],
           color:  color_index
         }
       end


### PR DESCRIPTION
Consider `has_many :tickets, class_name: 'Bus::Ticket'` or `has_many :tickets, class_name: '::Bus::Ticket'`.

For these examples `refl_model` will be equal `bus/tickets` and `/bus/tickets` that will not found expected model in `model_list`.