### PR TITLE
Fix filter js error, add 'check all'

### DIFF
--- a/lib/templates/js.html
+++ b/lib/templates/js.html
@@ -2,11 +2,25 @@
   $(".visible").click(function() {
     var klass = $(this).attr("id");
 
-    if ($(this).prop("checked")){
-      $("." + klass).show();
+    if ($(this).prop("checked")) {
+      $(document.getElementsByClassName(klass)).show();
     }
     else {
-      $("." + klass).hide();
+      $(document.getElementsByClassName(klass)).hide();
+    }
+  });
+
+  $("#check-all").click(function() {
+    if($(this).prop("checked")) {
+      $(".visible").each(function() {
+        $(this).prop("checked", false);
+        $(this).click();
+      });
+    } else {
+      $(".visible").each(function() {
+        $(this).prop("checked", true);
+        $(this).click();
+      });
     }
   });
 

--- a/lib/templates/modals.html.erb
+++ b/lib/templates/modals.html.erb
@@ -86,6 +86,10 @@
                 <th>#</th>
                 <th>name</th>
                 <th>show</th>
+                <th>
+                  check all
+                  <input id="check-all" type="checkbox" value="" checked>
+                </th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Js error - When class name  includes colon ( `<div class="ActiveAdmin::Comment">`), it inpossible to use it in jquery search like `$(.class_name)`. So I changed with `getElementsByClassName` instead. Also 'check all' checkbox added to filter